### PR TITLE
Adding Data Model And Storage

### DIFF
--- a/src/main/java/com/example/alva/datamodel/VisitorProcess.java
+++ b/src/main/java/com/example/alva/datamodel/VisitorProcess.java
@@ -58,7 +58,7 @@ public class VisitorProcess {
     }
 
     public String getId() {
-        return id;
+        return this.id;
     }
 
     public void setId(final String id) {
@@ -68,7 +68,7 @@ public class VisitorProcess {
     }
 
     public URL getBaseURL() {
-        return baseURL;
+        return this.baseURL;
     }
 
     public void setBaseURL(final URL baseURL) {
@@ -76,7 +76,7 @@ public class VisitorProcess {
     }
 
     public ProcessStatus getStatus() {
-        return status;
+        return this.status;
     }
 
     public void setStatus(final ProcessStatus status) {
@@ -84,7 +84,7 @@ public class VisitorProcess {
     }
 
     public String getUpdateLink() {
-        return updateLink;
+        return this.updateLink;
     }
 
     public void setUpdateLink(final String updateLink) {
@@ -92,7 +92,7 @@ public class VisitorProcess {
     }
 
     public String getResultLink() {
-        return resultLink;
+        return this.resultLink;
     }
 
     public void setResultLink(final String resultLink) {

--- a/src/main/java/com/example/alva/datamodel/VisitorProcess.java
+++ b/src/main/java/com/example/alva/datamodel/VisitorProcess.java
@@ -1,0 +1,105 @@
+package com.example.alva.datamodel;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class VisitorProcess {
+
+    private static final String API_BASE = "/api/v1";
+    private static final String UPDATE_URL_FORMAT = "%s" + API_BASE + "/visitors/%s";
+    private static final String RESULT_URL_FORMAT = "%s" + API_BASE + "/visitors/%s/result";
+    @JsonProperty("process_id")
+    private String id;
+    @JsonProperty("base_url")
+    private URL baseURL;
+    @JsonProperty("process_status")
+    private ProcessStatus status = ProcessStatus.ACTIVE;
+    @JsonProperty("update_link")
+    private String updateLink;
+    @JsonProperty("result_link")
+    private String resultLink;
+
+    public VisitorProcess(final HttpServletRequest request, final URL baseURL) {
+        this.id = UUID.randomUUID().toString();
+        this.baseURL = baseURL;
+        this.updateLink = createUpdateLink(request, this.id);
+        this.resultLink = createResultLink(request, this.id);
+    }
+
+    public VisitorProcess(final URL baseURL) {
+        this(null, baseURL);
+    }
+
+    private static String createUpdateLink(final HttpServletRequest request, final String id) {
+        return String.format(UPDATE_URL_FORMAT, getURLBase(request).orElse("localhost:8080"), id);
+    }
+
+    private static String createResultLink(final HttpServletRequest request, final String id) {
+        return String.format(RESULT_URL_FORMAT, getURLBase(request).orElse("localhost:8080"), id);
+    }
+
+    private static Optional<String> getURLBase(final HttpServletRequest request) {
+        try {
+            if (request == null) {
+                return Optional.empty();
+            }
+            URL url = new URL(request.getRequestURL().toString());
+
+            String port = url.getPort() == -1 ? "" : ":" + url.getPort();
+            return Optional.of(url.getProtocol() + "://" + url.getHost() + port);
+        } catch (MalformedURLException e) {
+            return Optional.empty();
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        if (this.id == null) {
+            this.id = id;
+        }
+    }
+
+    public URL getBaseURL() {
+        return baseURL;
+    }
+
+    public void setBaseURL(final URL baseURL) {
+        this.baseURL = baseURL;
+    }
+
+    public ProcessStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(final ProcessStatus status) {
+        this.status = status;
+    }
+
+    public String getUpdateLink() {
+        return updateLink;
+    }
+
+    public void setUpdateLink(final String updateLink) {
+        this.updateLink = updateLink;
+    }
+
+    public String getResultLink() {
+        return resultLink;
+    }
+
+    public void setResultLink(final String resultLink) {
+        this.resultLink = resultLink;
+    }
+
+    public enum ProcessStatus {
+        ACTIVE, DONE
+    }
+}

--- a/src/main/java/com/example/alva/datamodel/VisitorResult.java
+++ b/src/main/java/com/example/alva/datamodel/VisitorResult.java
@@ -12,7 +12,7 @@ public class VisitorResult {
     }
 
     public String getId() {
-        return id;
+        return this.id;
     }
 
     public void setId(final String id) {

--- a/src/main/java/com/example/alva/datamodel/VisitorResult.java
+++ b/src/main/java/com/example/alva/datamodel/VisitorResult.java
@@ -1,0 +1,23 @@
+package com.example.alva.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class VisitorResult {
+
+    @JsonProperty("process_id")
+    private String id;
+
+    public VisitorResult(final VisitorProcess process) {
+        this.id = process.getId();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        if (this.id == null) {
+            this.id = id;
+        }
+    }
+}

--- a/src/main/java/com/example/alva/storage/AbstractCacheBasedGenericStorage.java
+++ b/src/main/java/com/example/alva/storage/AbstractCacheBasedGenericStorage.java
@@ -1,0 +1,29 @@
+package com.example.alva.storage;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+abstract class AbstractCacheBasedGenericStorage<K, V> implements GenericStorage<K, V> {
+
+    private final Cache<K, V> cache;
+
+    protected AbstractCacheBasedGenericStorage() {
+        this.cache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build();
+    }
+
+    protected abstract K getIdentifierFromValue(final V value);
+
+    @Override
+    public void save(final V value) {
+        this.cache.put(Objects.requireNonNull(this.getIdentifierFromValue(value)), value);
+    }
+
+    @Override
+    public Optional<V> get(final K key) {
+        return Optional.ofNullable(this.cache.getIfPresent(key));
+    }
+}

--- a/src/main/java/com/example/alva/storage/GenericStorage.java
+++ b/src/main/java/com/example/alva/storage/GenericStorage.java
@@ -1,0 +1,10 @@
+package com.example.alva.storage;
+
+import java.util.Optional;
+
+public interface GenericStorage<K, V> {
+
+    void save(V value);
+
+    Optional<V> get(K key);
+}

--- a/src/main/java/com/example/alva/storage/InMemoryProcessStorage.java
+++ b/src/main/java/com/example/alva/storage/InMemoryProcessStorage.java
@@ -1,30 +1,15 @@
 package com.example.alva.storage;
 
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.stereotype.Component;
 
 import com.example.alva.datamodel.VisitorProcess;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 @Component
-public class InMemoryProcessStorage implements ProcessStorage {
-
-    private final Cache<String, VisitorProcess> cache;
-
-    private InMemoryProcessStorage() {
-        this.cache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build();
-    }
+public class InMemoryProcessStorage extends AbstractCacheBasedGenericStorage<String, VisitorProcess>
+    implements ProcessStorage {
 
     @Override
-    public void save(final VisitorProcess visitorProcess) {
-        this.cache.put(visitorProcess.getId(), visitorProcess);
-    }
-
-    @Override
-    public Optional<VisitorProcess> get(final String key) {
-        return Optional.ofNullable(this.cache.getIfPresent(key));
+    protected String getIdentifierFromValue(final VisitorProcess value) {
+        return value.getId();
     }
 }

--- a/src/main/java/com/example/alva/storage/InMemoryProcessStorage.java
+++ b/src/main/java/com/example/alva/storage/InMemoryProcessStorage.java
@@ -1,0 +1,30 @@
+package com.example.alva.storage;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.example.alva.datamodel.VisitorProcess;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+@Component
+public class InMemoryProcessStorage implements ProcessStorage {
+
+    private final Cache<String, VisitorProcess> cache;
+
+    private InMemoryProcessStorage() {
+        this.cache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build();
+    }
+
+    @Override
+    public void save(final VisitorProcess visitorProcess) {
+        this.cache.put(visitorProcess.getId(), visitorProcess);
+    }
+
+    @Override
+    public Optional<VisitorProcess> get(final String key) {
+        return Optional.ofNullable(this.cache.getIfPresent(key));
+    }
+}

--- a/src/main/java/com/example/alva/storage/InMemoryResultStorage.java
+++ b/src/main/java/com/example/alva/storage/InMemoryResultStorage.java
@@ -1,30 +1,15 @@
 package com.example.alva.storage;
 
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.stereotype.Component;
 
 import com.example.alva.datamodel.VisitorResult;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 @Component
-public class InMemoryResultStorage implements ResultStorage {
-
-    private final Cache<String, VisitorResult> cache;
-
-    private InMemoryResultStorage() {
-        this.cache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build();
-    }
+public class InMemoryResultStorage extends AbstractCacheBasedGenericStorage<String, VisitorResult>
+    implements ResultStorage {
 
     @Override
-    public void save(final VisitorResult result) {
-        this.cache.put(result.getId(), result);
-    }
-
-    @Override
-    public Optional<VisitorResult> get(final String key) {
-        return Optional.ofNullable(this.cache.getIfPresent(key));
+    protected String getIdentifierFromValue(final VisitorResult value) {
+        return value.getId();
     }
 }

--- a/src/main/java/com/example/alva/storage/InMemoryResultStorage.java
+++ b/src/main/java/com/example/alva/storage/InMemoryResultStorage.java
@@ -1,0 +1,30 @@
+package com.example.alva.storage;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.example.alva.datamodel.VisitorResult;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+@Component
+public class InMemoryResultStorage implements ResultStorage {
+
+    private final Cache<String, VisitorResult> cache;
+
+    private InMemoryResultStorage() {
+        this.cache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build();
+    }
+
+    @Override
+    public void save(final VisitorResult result) {
+        this.cache.put(result.getId(), result);
+    }
+
+    @Override
+    public Optional<VisitorResult> get(final String key) {
+        return Optional.ofNullable(this.cache.getIfPresent(key));
+    }
+}

--- a/src/main/java/com/example/alva/storage/ProcessStorage.java
+++ b/src/main/java/com/example/alva/storage/ProcessStorage.java
@@ -1,0 +1,5 @@
+package com.example.alva.storage;
+
+import com.example.alva.datamodel.VisitorProcess;
+
+public interface ProcessStorage extends GenericStorage<String, VisitorProcess> {}

--- a/src/main/java/com/example/alva/storage/ResultStorage.java
+++ b/src/main/java/com/example/alva/storage/ResultStorage.java
@@ -1,0 +1,5 @@
+package com.example.alva.storage;
+
+import com.example.alva.datamodel.VisitorResult;
+
+public interface ResultStorage extends GenericStorage<String, VisitorResult> {}

--- a/src/test/java/com/example/alva/storage/AbstractCacheBasedGenericStorageTest.java
+++ b/src/test/java/com/example/alva/storage/AbstractCacheBasedGenericStorageTest.java
@@ -1,0 +1,34 @@
+package com.example.alva.storage;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+public class AbstractCacheBasedGenericStorageTest
+    extends CacheBasedStorageContractVerifier<Integer, Pair<Integer, String>> {
+
+    private static final Pair<Integer, String> EXISTING_ENTITY = Pair.of(0, "existing");
+    private static final Pair<Integer, String> OVERRIDING_ENTITY = Pair.of(EXISTING_ENTITY.getKey(), "new");
+    private static final Pair<Integer, String> MISSING_ENTITY = Pair.of(100, "missing");
+    private static final Pair<Integer, String> NULL_ENTITY = Pair.of(null, "existing");
+
+    public AbstractCacheBasedGenericStorageTest() {
+        super(newTupleFrom(EXISTING_ENTITY), newTupleFrom(OVERRIDING_ENTITY), newTupleFrom(MISSING_ENTITY),
+            newTupleFrom(NULL_ENTITY));
+    }
+
+    private static Pair<Integer, Pair<Integer, String>> newTupleFrom(final Pair<Integer, String> entity) {
+        return Pair.of(entity.getKey(), entity);
+    }
+
+    @Override
+    protected AbstractCacheBasedGenericStorage<Integer, Pair<Integer, String>> newInstance() {
+        return new TestStorage();
+    }
+
+    private static final class TestStorage extends AbstractCacheBasedGenericStorage<Integer, Pair<Integer, String>> {
+
+        @Override
+        protected Integer getIdentifierFromValue(final Pair<Integer, String> value) {
+            return value.getLeft();
+        }
+    }
+}

--- a/src/test/java/com/example/alva/storage/CacheBasedStorageContractVerifier.java
+++ b/src/test/java/com/example/alva/storage/CacheBasedStorageContractVerifier.java
@@ -1,0 +1,61 @@
+package com.example.alva.storage;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class CacheBasedStorageContractVerifier<K, V> {
+
+    private final Pair<K, V> existingEntity;
+    private final Pair<K, V> overridingEntity;
+    private final Pair<K, V> missingEntity;
+    private final Pair<K, V> nullEntity;
+    private AbstractCacheBasedGenericStorage<K, V> storage;
+
+    public CacheBasedStorageContractVerifier(final Pair<K, V> existingEntity, final Pair<K, V> overridingEntity,
+        final Pair<K, V> missingEntity, final Pair<K, V> nullEntity) {
+        this.existingEntity = existingEntity;
+        this.overridingEntity = overridingEntity;
+        this.missingEntity = missingEntity;
+        this.nullEntity = nullEntity;
+    }
+
+    protected abstract AbstractCacheBasedGenericStorage<K, V> newInstance();
+
+    @Before
+    public void setUp() {
+        this.storage = this.newInstance();
+        this.storage.save(this.existingEntity.getValue());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void save_nullIdentifier() {
+        this.storage.save(this.nullEntity.getValue());
+    }
+
+    @Test
+    public void save_overridingExistingEntity() {
+        this.storage.save(this.overridingEntity.getValue());
+        final Optional<V> get = this.storage.get(this.existingEntity.getKey());
+
+        assertThat(get.isPresent()).isTrue();
+        assertThat(get.get()).isEqualTo(this.overridingEntity.getValue());
+    }
+
+    @Test
+    public void get_existingEntity() {
+        final Optional<V> get = this.storage.get(this.existingEntity.getKey());
+        assertThat(get.isPresent()).isTrue();
+        assertThat(get.get()).isEqualTo(this.existingEntity.getValue());
+    }
+
+    @Test
+    public void get_missingEntity() {
+        final Optional<V> get = this.storage.get(this.missingEntity.getKey());
+        assertThat(get.isPresent()).isFalse();
+    }
+}

--- a/src/test/java/com/example/alva/storage/InMemoryProcessStorageTest.java
+++ b/src/test/java/com/example/alva/storage/InMemoryProcessStorageTest.java
@@ -1,0 +1,63 @@
+package com.example.alva.storage;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.UUID;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.example.alva.datamodel.VisitorProcess;
+
+public class InMemoryProcessStorageTest extends CacheBasedStorageContractVerifier<String, VisitorProcess> {
+
+    private static final URI BASE_URI = URI.create("http://www.google.com");
+    private static final UUID EXISTING_UUID = UUID.randomUUID();
+
+    public InMemoryProcessStorageTest() throws MalformedURLException {
+
+        this(newPairFrom(createProcessSpy(EXISTING_UUID.toString())),
+            newPairFrom(createProcessSpy(EXISTING_UUID.toString())),
+            newPairFrom(createProcessSpy(UUID.randomUUID().toString())), newPairFrom(createProcessMock()));
+    }
+
+    private InMemoryProcessStorageTest(final Pair<String, VisitorProcess> existingEntity,
+        final Pair<String, VisitorProcess> overridingEntity, final Pair<String, VisitorProcess> missingEntity,
+        final Pair<String, VisitorProcess> nullEntity) {
+        super(newPairFrom(existingEntity.getValue()), overridingEntity, missingEntity, nullEntity);
+    }
+
+    private static VisitorProcess createProcessSpy(final String id) throws MalformedURLException {
+        final VisitorProcess spy = Mockito.spy(new VisitorProcess(getBaseURL()));
+        Mockito.when(spy.getId()).thenReturn(id);
+        return spy;
+    }
+
+    private static VisitorProcess createProcessMock() {
+        return Mockito.mock(VisitorProcess.class);
+    }
+
+    private static URL getBaseURL() throws MalformedURLException {
+        return BASE_URI.toURL();
+    }
+
+    private static Pair<String, VisitorProcess> newPairFrom(final VisitorProcess value) {
+        return Pair.of(value.getId(), value);
+    }
+
+    @Test
+    public void getIdentifierFromValue() throws MalformedURLException {
+        final VisitorProcess process = new VisitorProcess(getBaseURL());
+        final String identifier = new InMemoryProcessStorage().getIdentifierFromValue(process);
+
+        Assertions.assertThat(identifier).isEqualTo(process.getId());
+    }
+
+    @Override
+    protected AbstractCacheBasedGenericStorage<String, VisitorProcess> newInstance() {
+        return new InMemoryProcessStorage();
+    }
+}

--- a/src/test/java/com/example/alva/storage/InMemoryResultStorageTest.java
+++ b/src/test/java/com/example/alva/storage/InMemoryResultStorageTest.java
@@ -1,0 +1,60 @@
+package com.example.alva.storage;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.UUID;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.example.alva.datamodel.VisitorProcess;
+import com.example.alva.datamodel.VisitorResult;
+
+public class InMemoryResultStorageTest extends CacheBasedStorageContractVerifier<String, VisitorResult> {
+
+    private static final URI BASE_URI = URI.create("http://www.google.com");
+    private static final UUID EXISTING_UUID = UUID.randomUUID();
+
+    public InMemoryResultStorageTest() throws MalformedURLException {
+
+        this(newPairFrom(createNewResult(EXISTING_UUID.toString())),
+            newPairFrom(createNewResult(EXISTING_UUID.toString())),
+            newPairFrom(createNewResult(UUID.randomUUID().toString())), newPairFrom(createNewResult(null)));
+    }
+
+    private InMemoryResultStorageTest(final Pair<String, VisitorResult> existingEntity,
+        final Pair<String, VisitorResult> overridingEntity, final Pair<String, VisitorResult> missingEntity,
+        final Pair<String, VisitorResult> nullEntity) {
+        super(newPairFrom(existingEntity.getValue()), overridingEntity, missingEntity, nullEntity);
+    }
+
+    private static VisitorResult createNewResult(final String id) throws MalformedURLException {
+        final VisitorProcess spy = Mockito.spy(new VisitorProcess(getBaseURL()));
+        Mockito.when(spy.getId()).thenReturn(id);
+        return new VisitorResult(spy);
+    }
+
+    private static URL getBaseURL() throws MalformedURLException {
+        return BASE_URI.toURL();
+    }
+
+    private static Pair<String, VisitorResult> newPairFrom(final VisitorResult value) {
+        return Pair.of(value.getId(), value);
+    }
+
+    @Test
+    public void getIdentifierFromValue() throws MalformedURLException {
+        final VisitorResult result = new VisitorResult(new VisitorProcess(getBaseURL()));
+        final String identifier = new InMemoryResultStorage().getIdentifierFromValue(result);
+
+        Assertions.assertThat(identifier).isEqualTo(result.getId());
+    }
+
+    @Override
+    protected AbstractCacheBasedGenericStorage<String, VisitorResult> newInstance() {
+        return new InMemoryResultStorage();
+    }
+}


### PR DESCRIPTION
- adding basic data model for running processes that will be retrievable by REST API
- adding simple storage mechanism for data models; using Google caches for in-memory storage
  - initial cache setup defines interval-based retention policy, removing entities after 1 (one) hour
  - data will not be persisted between server restarts